### PR TITLE
Fix History Bug

### DIFF
--- a/FE/src/services/initialize.ts
+++ b/FE/src/services/initialize.ts
@@ -17,17 +17,23 @@ const routeParamsToStore = (routeParams: Record<string, string>) => {
     store.dispatch(setFilterRouteParams(routeParams));
 };
 
-const handlePopState = (event: { state: any }) => {
-    if (!event.state) return;
-    routeParamsToStore(event.state);
+const hydrateFromLocation = () => {
+    window.__suppressHistoryPush = true;
+    const currentParams = getRouteParams();
+    routeParamsToStore(currentParams);
+    setTimeout(() => { window.__suppressHistoryPush = false; }, 0);
 };
+
+const handlePopState = () => {
+    hydrateFromLocation();
+};
+
 export default async (main: React.ReactNode) => {
-    const routeParams = getRouteParams();
-    if(routeParams) routeParamsToStore(routeParams);
+    hydrateFromLocation();
 
     if(await loadConfig()) {
         analytics.init();
-        mapService.init({mapInteractions, viewInteractions})
+        mapService.init({mapInteractions, viewInteractions});
         setAllLocationsInStore();
     }
 

--- a/FE/src/services/loadConfig.ts
+++ b/FE/src/services/loadConfig.ts
@@ -16,6 +16,7 @@ declare global {
         metaTags: any
         environment: any;
         handleMapFeatureClick: (event: Event, cardId: string, lengthOfFeatures: number) => void;
+        __suppressHistoryPush: boolean
     }
 }
 

--- a/FE/src/services/url/route.tsx
+++ b/FE/src/services/url/route.tsx
@@ -1,35 +1,64 @@
 import {useSelector} from "react-redux";
 import {getUrlParams} from "../../store/shared/urlSelector";
-import {debounced} from "../debounced";
 
 const globals = {
-    lockUpdateURL: false,
-}
+    initialized: false,
+    lastQuery: "",
+    lastNavKey: ""
+};
 
 export const getRouteParams = () => {
     const searchParams = new URLSearchParams(window.location.search);
     return Object.fromEntries(searchParams);
-}
+};
 
-const updateHistory = (urlParams: Record<string, string>) => {
-    const urlParamString = new URLSearchParams(urlParams).toString();
+const buildUrl = (params: Record<string,string>) => {
+    const qs = new URLSearchParams(params).toString();
     const base = window.location.pathname;
     const hash = window.location.hash;
+    return qs ? base + "?" + qs + hash : base + hash;
+};
 
-    let newUrl: string;
-    if (urlParamString) {
-        newUrl = base + "?" + urlParamString + hash;
-    } else {
-        newUrl = base + hash;
+const navKey = (params: Record<string,string>) => {
+    const p = params.p || 'home';
+    if (p === 'card') return `card|${params.c || ''}`;
+    return p + '|';
+};
+
+const applyHistory = (params: Record<string,string>) => {
+    const qs = new URLSearchParams(params).toString();
+    const key = navKey(params);
+    const suppress = window.__suppressHistoryPush;
+
+    if (!globals.initialized) {
+        // Initial sync: never push, just replace
+        window.history.replaceState(params, "", buildUrl(params));
+        globals.initialized = true;
+        globals.lastQuery = qs;
+        globals.lastNavKey = key;
+        return;
     }
-    window.history.replaceState(urlParams, "", newUrl);
-}
 
-const debouncedHistoryUpdate = debounced(updateHistory, 100);
+    // If hydration suppression is active, just record and exit
+    if (suppress) {
+        globals.lastQuery = qs;
+        globals.lastNavKey = key;
+        return;
+    }
+
+    if (qs === globals.lastQuery) return;
+
+    const url = buildUrl(params);
+    if (key !== globals.lastNavKey) {
+        window.history.pushState(params, "", url);
+    } else {
+        window.history.replaceState(params, "", url);
+    }
+    globals.lastQuery = qs;
+    globals.lastNavKey = key;
+};
 
 export const useRouteUpdater = () => {
-    const urlParams = useSelector(getUrlParams);
-    if (globals.lockUpdateURL) return;
-    debouncedHistoryUpdate(urlParams);
+    const params = useSelector(getUrlParams) as Record<string,string>;
+    applyHistory(params);
 };
-export const setLockUpdateURL = (lock: boolean) => globals.lockUpdateURL = lock;

--- a/FE/src/store/general/generalSlice.ts
+++ b/FE/src/store/general/generalSlice.ts
@@ -10,22 +10,17 @@ export const generalSlice = createSlice({
             state.modal = action.payload.m || state.modal;
             state.cardId = action.payload.c || state.cardId;
             state.searchQuery = action.payload.sq || state.searchQuery;
-            state.oldURL = action.payload.old === 'true' || false;
+            state.oldURL = action.payload?.old === 'true' || false;
         },
         setPage(state: GeneralStore, action) {
             if (!action.payload) {
-                state.page = 'home'
-                state.oldURL = false;
+                state.page = 'home';
                 return;
             }
             state.page = action.payload;
-            if (action.payload !== 'results') state.oldURL = false;
         },
         setSearchQuery(state: GeneralStore, action) {
             state.searchQuery = action.payload;
-            if (!action.payload) {
-                state.oldURL = false;
-            }
         },
         setModal(state: GeneralStore, action) {
             state.modal = action.payload;
@@ -38,9 +33,7 @@ export const generalSlice = createSlice({
         },
         setCardIdAndCardPage(state: GeneralStore, action) {
             state.cardId = action.payload;
-            state.page = 'card'
-            // Leaving results: clear oldURL flag
-            state.oldURL = false;
+            state.page = 'card';
         },
         setAccessibility(state: GeneralStore, action) {
             state.accessibilityActive = action.payload;

--- a/FE/src/store/general/initialState.ts
+++ b/FE/src/store/general/initialState.ts
@@ -1,5 +1,5 @@
 export const initialState = {
-    page: "card",
+    page: "home",
     modal: null,
     cardId: "",
     searchQuery:"",


### PR DESCRIPTION
מה השינוי העיקרי

לפני השינוי, כשאתה לוחץ Back, הדפדפן שולח אירוע popstate כדי לשחזר את הכתובת הישנה, אבל הקוד שלנו היה מתייחס לזה כ" שינוי URL חדש" ומבצע push או replace שוב. זה גרם לכך שלחיצה על Back לא באמת עשתה את מה שציפינו – לפעמים הדפדפן חזר אחורה ואז מיד דחף את הכתובת חזרה קדימה.

השינוי העיקרי הוא:

בהתחלת הטעינה (initialize.ts) או כשמתרחש אירוע popstate (לחיצה על Back/Forward), אנחנו מגדירים דגל גלובלי על window:

window.__suppressHistoryPush = true;


זה אומר: "עכשיו אנחנו רק משחזרים את המצב הקודם, אל תעדכן את ההיסטוריה".

בפונקציה applyHistory:

const suppress = (window as any).__suppressHistoryPush === true;


אם suppress = true → אין push/replace, רק שמירה פנימית של globals.lastQuery ו-globals.lastNavKey.

אחרי שההתחלה/שחזור הסתיים, אפשר להוריד את הדגל (למשל עם setTimeout) כדי לאפשר עדכונים רגילים בהמשך.

איך זה עובד עכשיו

טעינה ראשונית:

window.history.replaceState בלבד → לא מוסיפים כניסה חדשה בהיסטוריה.

לחיצה על Back/Forward:

הדגל __suppressHistoryPush = true → לא יוצרים או מחליפים כניסה בהיסטוריה, רק מעדכנים את המצב הפנימי.

ניווט רגיל בין דפים:

אם ה"page/card" משתנה → pushState (כניסה חדשה בהיסטוריה).

אם רק פרמטרים בתוך הדף משתנים → replaceState (שינוי כתובת בלי ליצור כניסה חדשה).

מניעת כפילויות:

הקוד משווה את lastQuery עם הפרמטרים החדשים ומונע כתובות כפולות.

בסיכום

__suppressHistoryPush = דגל זמני שמסמן שאנחנו משחזרים את ההיסטוריה של הדפדפן, ולכן אסור לנו לשנות אותה כרגע.
אפשר לחשוב עליו כ-"תפסיקו לשחק עם ההיסטוריה עכשיו, אנחנו רק קוראים אותה".