### PR TITLE
Harden the BudgetKey and data.gov.il HTTP paths

### DIFF
--- a/ETL/data/plugins/srm-etl/srm_tools/budgetkey.py
+++ b/ETL/data/plugins/srm-etl/srm_tools/budgetkey.py
@@ -2,16 +2,24 @@ import requests
 
 from conf import settings
 from srm_tools.debug_cache import cache_get, cache_set
+from srm_tools.http_retry import request_with_retry
 
 CACHE_KEY_PREFIX = 'bk:'
 QUERY_FAILED_MESSAGE = 'BudgetKey query API returned success=false.\nSQL: {sql}\nResponse: {payload}'
+RETRY_DESCRIPTION = 'BudgetKey query API page {page_number}'
+DEFAULT_PAGE_COUNT = 1
 
 
 def fetch_budgetkey_query_page(sql, page_number):
-    response = requests.get(
-        settings.BUDGETKEY_QUERY_API,
-        params=dict(query=sql, page=page_number),
-        timeout=settings.BUDGETKEY_QUERY_TIMEOUT_SECONDS,
+    # operators/entities issues one of these per organization, so a single
+    # transient blip must not abort the whole run.
+    response = request_with_retry(
+        lambda: requests.get(
+            settings.BUDGETKEY_QUERY_API,
+            params=dict(query=sql, page=page_number),
+            timeout=settings.BUDGETKEY_QUERY_TIMEOUT_SECONDS,
+        ),
+        RETRY_DESCRIPTION.format(page_number=page_number),
     )
     response.raise_for_status()
     payload = response.json()
@@ -25,7 +33,7 @@ def fetch_all_budgetkey_query_pages(sql):
     # an empty set, so the page count must come from the response itself.
     first_page = fetch_budgetkey_query_page(sql, 0)
     rows = list(first_page['rows'])
-    for page_number in range(1, first_page['pages']):
+    for page_number in range(1, first_page.get('pages', DEFAULT_PAGE_COUNT)):
         rows.extend(fetch_budgetkey_query_page(sql, page_number)['rows'])
     return rows
 

--- a/ETL/data/plugins/srm-etl/srm_tools/datagovil.py
+++ b/ETL/data/plugins/srm-etl/srm_tools/datagovil.py
@@ -78,10 +78,18 @@ def resolve_datagovil_resource(dataset_name, resource_name):
 
 
 def fetch_datagovil_datastore(dataset_name, resource_name):
+    # Resolution and the first datastore call run eagerly, so an unpublished
+    # dataset or a renamed resource raises here - at the call site, naming the
+    # dataset - instead of surfacing later from inside the dataflows Flow that
+    # consumes the returned generator.
     resource_id = resolve_datagovil_resource(dataset_name, resource_name)['id']
-    payload = fetch_datagovil_json(
+    first_payload = fetch_datagovil_json(
         settings.DATAGOVIL_DATASTORE_SEARCH_API, dict(resource_id=resource_id)
     )
+    return iterate_datastore_records(first_payload, dataset_name)
+
+
+def iterate_datastore_records(payload, dataset_name):
     while True:
         records = payload.get('result', {}).get('records') or []
         if len(records) == 0:

--- a/ETL/data/plugins/srm-etl/srm_tools/http_retry.py
+++ b/ETL/data/plugins/srm-etl/srm_tools/http_retry.py
@@ -1,0 +1,55 @@
+"""Retry wrapper for outbound HTTP calls to third-party data sources.
+
+Retrying is this module's single responsibility, which is why the try/except
+lives here and nowhere in the call chain above it. Transient failures - a
+dropped connection, a read timeout, a 5xx from the upstream - are retried with
+exponential backoff. A 4xx is a real answer from a healthy server, so it is
+returned unretried for the caller to handle.
+"""
+import time
+
+import requests
+
+from srm_tools.logger import logger
+
+DEFAULT_MAX_ATTEMPTS = 4
+DEFAULT_BACKOFF_SECONDS = 2
+RETRYABLE_STATUS_FLOOR = 500
+
+
+def is_retryable_response(response):
+    return response.status_code >= RETRYABLE_STATUS_FLOOR
+
+
+def backoff_delay_seconds(attempt_number, backoff_seconds):
+    return backoff_seconds * (2 ** (attempt_number - 1))
+
+
+def log_retry(description, attempt_number, max_attempts, reason):
+    logger.info(
+        'Retrying %s (attempt %d/%d) after %s',
+        description, attempt_number, max_attempts, reason,
+    )
+
+
+def request_with_retry(perform_request, description,
+                       max_attempts=DEFAULT_MAX_ATTEMPTS,
+                       backoff_seconds=DEFAULT_BACKOFF_SECONDS):
+    """Call perform_request(), retrying transient failures. Returns its response.
+
+    The final attempt is never swallowed: a connection error propagates and a
+    5xx response is returned as-is so the caller's raise_for_status() reports it.
+    """
+    for attempt_number in range(1, max_attempts + 1):
+        is_last_attempt = attempt_number == max_attempts
+        try:
+            response = perform_request()
+        except requests.RequestException as error:
+            if is_last_attempt:
+                raise
+            log_retry(description, attempt_number, max_attempts, error)
+        else:
+            if is_last_attempt or not is_retryable_response(response):
+                return response
+            log_retry(description, attempt_number, max_attempts, f'HTTP {response.status_code}')
+        time.sleep(backoff_delay_seconds(attempt_number, backoff_seconds))


### PR DESCRIPTION
Follow-up to the `v1.17.0` review. Two live ETL code paths changed transport in that release; this hardens both. No behavior change to what the operators produce — verified below.

## What and why

### BudgetKey: retries (`srm_tools/http_retry.py`, `srm_tools/budgetkey.py`)

`v1.17.0` moved BudgetKey off a pooled Postgres connection onto per-call HTTP. `operators/entities` issues **one request per organization**, sequentially — and `raise_for_status()` meant a single transient 5xx aborted the entire run.

New `srm_tools/http_retry.py`:
- Retries `requests.RequestException` and 5xx with exponential backoff (4 attempts, 2s base).
- **Never retries a 4xx** — a 403/404 is a real answer from a healthy server, not a blip.
- Returns the final response rather than swallowing it, so the caller's `raise_for_status()` still reports a persistent 5xx.
- The `try/except` lives here and nowhere else in the call chain: retrying is this module's single responsibility.

Also guards `first_page['pages']`, which raised `KeyError` if the API omitted the key.

### data.gov.il: fail at the call site (`srm_tools/datagovil.py`)

`fetch_datagovil_datastore` is a generator, so `resolve_datagovil_resource` didn't run until dataflows pulled the first record — a missing dataset surfaced from inside `DF.Flow(...).process()` with a traceback pointing at the Flow.

Resolution and the first datastore call now run eagerly; the paging loop moves to `iterate_datastore_records`. **Failure semantics are unchanged** — it still raises, still fails the run, still emails. Only the timing and the traceback improve. Public signature and both call sites are untouched.

## Verification

Live A/B against the real APIs — the only diff between `main` and this branch was elapsed time:

| Check | Result |
|---|---|
| soproc suppliers CTE | 1,835 rows across **2 pages** (1000/page) — exercises the paging loop |
| entities single lookup | found; `details` is a **dict**, so `details.get('goal')` still works |
| soproc `select * from activities` | 1 page, 236 rows |

Retry semantics, stubbed (no network): retries transient errors then succeeds (3 calls) · retries 5xx to max_attempts (4 calls) · **does not** retry 4xx (1 call) · both surface as `HTTPError` at the budgetkey layer · missing `pages` key returns the first page.

data.gov.il: unpublished dataset raises **eagerly**, names the dataset, reports HTTP 403 · wrong resource name raises eagerly and lists what's available · happy path still streams (329 records) · error propagates out of `invoke_on` as `DatagovilSourceError` with the notifier fired (SMTP stubbed, no mail sent).

## Notes for review

- **Operators were deliberately not run end to end.** `soproc.fetchOrgData` and `entities.updateOrgFromSourceData` both finish with `airtable_updater` against the live Data-Import base. Testing drove `fetch_from_budgetkey` directly with the exact queries those operators issue.
- `mental_health_clinics` will keep hard-failing on every scheduled run — the dataset is 403 upstream with no code-side fix. That is the intended behavior; the Cronicle schedule is deliberately left enabled.
- Pre-existing, not addressed here: if SMTP itself fails, `send_failure_email` raises a new exception that masks the original traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
