### PR TITLE
Build arm64-only images and fix the gitignore artifacts block

### DIFF
--- a/.github/workflows/fe-ACR.yml
+++ b/.github/workflows/fe-ACR.yml
@@ -92,7 +92,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             environment=${{ steps.get_version.outputs.TARGET_ENV }}
-          platforms: linux/amd64,linux/arm64
+          # The AKS node pools are ARM, so amd64 is dead weight in both build
+          # time and ACR storage.
+          platforms: linux/arm64
           provenance: false
 
       # ── Non-Prod Deployment Setup ────────────────────────────
@@ -155,7 +157,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             environment=${{ steps.get_version.outputs.TARGET_ENV }}
-          platforms: linux/amd64,linux/arm64
+          # The AKS node pools are ARM, so amd64 is dead weight in both build
+          # time and ACR storage.
+          platforms: linux/arm64
           provenance: false
 
       - name: Deploy SSG to Non-Prod

--- a/.github/workflows/reusable-build-deploy.yml
+++ b/.github/workflows/reusable-build-deploy.yml
@@ -147,7 +147,9 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           build-args: |
             ENVIRONMENT=${{ steps.get_version.outputs.VERSION }}
-          platforms: linux/amd64,linux/arm64
+          # The AKS node pools are ARM, so amd64 is dead weight in both build
+          # time and ACR storage.
+          platforms: linux/arm64
           provenance: false
 
       - name: Azure Login

--- a/.gitignore
+++ b/.gitignore
@@ -187,15 +187,11 @@ ES/kibana/.env
 ETL/data/plugins/srm-etl/verification/reports/
 
 .claude
-test-scripts
-*artifacts
+test-scripts/
 
-# Exception: the retrieval embedding model is shipped via Git LFS (see .gitattributes)
-# so CI can bake it into the image. Its Hugging Face download cache stays ignored.
-!retrieval/artifacts/
-!retrieval/artifacts/retrieval-model/
-!retrieval/artifacts/retrieval-model/**
-retrieval/artifacts/retrieval-model/**/.cache/
+# The retrieval embedding model is tracked via Git LFS (see .gitattributes) so CI can
+# bake it into the image. Only its Hugging Face download cache is ignored.
+retrieval/artifacts/**/.cache/
 
 # Graphify knowledge graph output (built in CI, see README "Codebase Knowledge Graph")
 graphify-out/


### PR DESCRIPTION
Follow-up to the `v1.17.0` review. Config only — no application code changes.

## ✅ Pre-merge architecture check — cleared

Dropping `linux/amd64` means these images **cannot run on an x64 node**. Verified with:

```bash
kubectl get nodes -o custom-columns=NAME:.metadata.name,ARCH:.status.nodeInfo.architecture
```

- [x] **prod** — `arm64` · `aks-agentnode-42606649-vmss00000c`, `aks-usernode-30127214-vmss00000e`
- [x] **stage** — `arm64` · `aks-agentnode2-33198417-vmss000032`, `aks-usernode-10934990-vmss000031`
- [x] **dev** — assumed identical to stage and prod, not directly queried

Prod and stage were each checked directly. **Dev is an assumption, not a measurement.** If a future dev pool ever comes up amd64, dev deploys break first — which is the safe place to discover it.

## arm64-only builds

The cluster is ARM, so the amd64 half of every multi-arch build was dead weight: double the build time under QEMU, double the ACR storage, for a layer nothing can schedule.

`platforms: linux/amd64,linux/arm64` → `linux/arm64` in three places — `reusable-build-deploy.yml` (covers BE, ETL and retrieval) and both FE build steps in `fe-ACR.yml` (FE has its own standalone workflow, it does not use the reusable one).

Runners stay on `ubuntu-latest` and `setup-qemu-action` stays — emulation is still required to produce arm64 on an x64 runner. This is a **reduction in work**, not new risk on the build side: the arm64 leg already builds successfully today as half of the existing multi-arch build.

*Deferred, noted for later:* retrieval's emulated arm64 torch build stays slow. If that becomes a problem, `runs-on: ubuntu-24.04-arm` (free on public repos) makes it native and removes QEMU entirely.

## `.gitignore` cleanup

The block added in `v1.17.0` cancels itself out:

```
*artifacts                              # matches exactly one path: retrieval/artifacts
!retrieval/artifacts/                   # ...which these three immediately re-include
!retrieval/artifacts/retrieval-model/
!retrieval/artifacts/retrieval-model/**
retrieval/artifacts/retrieval-model/**/.cache/
```

Net effect today is nil. Its only live consequence is latent: a bare `*artifacts` silently ignores any future `<something>artifacts` path anywhere in the repo. Replaced with the single rule that does real work, plus a trailing slash on `test-scripts/` so it matches directories only.

Safe by construction — tracked files are unaffected by ignore rules, so the LFS model stays tracked.

## Verification

- `grep platforms .github/workflows/*.yml` → no `linux/amd64` remains.
- Both workflows still parse as YAML.
- `git check-ignore` — `model.safetensors` **not** ignored; `.cache/x` **is** ignored.
- `git ls-files retrieval/artifacts/` → all 9 model files still tracked.
- `git status` → only the three intended files changed; nothing newly untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
