### PR TITLE
Fix search bar crash on "." by moving the autocomplete term to a query param

### DIFF
--- a/FE/public/configs/config.json
+++ b/FE/public/configs/config.json
@@ -24,7 +24,7 @@
     "logs": "/logs",
     "search": "/search",
     "card": "/card/%%cardId%%",
-    "autocomplete": "/autocomplete/%%search%%",
+    "autocomplete": "/autocomplete?search=%%search%%",
     "siteMapForModal": "/siteMapForModal"
   },
   "map": {

--- a/FE/src/hooks/useSearchAutocomplete.ts
+++ b/FE/src/hooks/useSearchAutocomplete.ts
@@ -2,6 +2,7 @@ import {ChangeEvent} from "react";
 import {useDebounce} from "./useDebounce";
 import AutocompleteType from "../types/autocompleteType";
 import sendMessage from "../services/sendMessage/sendMessage";
+import buildAutocompleteRequestURL from "../services/searchUtilities/buildAutocompleteRequestURL";
 
 interface Params {
     setSearchTerm: React.Dispatch<React.SetStateAction<string>>;
@@ -13,10 +14,11 @@ const emptyAutocomplete: AutocompleteType = {structured: [], unstructured: []};
 
 const useSearchAutocomplete = ({setSearchTerm, setOptionalSearchValues, debounceMs = 500}: Params) => {
     const debouncedGetAutoComplete = useDebounce(async (value: unknown) => {
-        if (value === '') return setOptionalSearchValues(emptyAutocomplete);
-        const requestURL = window.config.routes.autocomplete.replace('%%search%%', value);
+        const searchTerm = String(value ?? '').trim();
+        if (searchTerm === '') return setOptionalSearchValues(emptyAutocomplete);
+        const requestURL = buildAutocompleteRequestURL(searchTerm);
         const response = await sendMessage({method: 'get', requestURL});
-        setOptionalSearchValues(response.data);
+        setOptionalSearchValues(response?.success && response.data ? response.data : emptyAutocomplete);
     }, debounceMs);
 
     const inputChangeEvent = (v: ChangeEvent<HTMLInputElement>) => {

--- a/FE/src/services/searchUtilities/buildAutocompleteRequestURL.ts
+++ b/FE/src/services/searchUtilities/buildAutocompleteRequestURL.ts
@@ -1,0 +1,12 @@
+const searchMacro = '%%search%%';
+
+// The typed term must never reach the URL raw: it travels as a query-string value, so
+// every reserved character has to be percent-encoded. The replacement is passed as a
+// function on purpose - String.replace with a string replacement treats `$&`, `$'`,
+// backtick-$ and `$1` as capture references, and encodeURIComponent leaves `$` untouched.
+const buildAutocompleteRequestURL = (searchTerm: string): string => {
+    const encodedSearchTerm = encodeURIComponent(searchTerm);
+    return window.config.routes.autocomplete.replace(searchMacro, () => encodedSearchTerm);
+};
+
+export default buildAutocompleteRequestURL;

--- a/FE/src/services/searchUtilities/buildAutocompleteRequestURL.ts
+++ b/FE/src/services/searchUtilities/buildAutocompleteRequestURL.ts
@@ -1,12 +1,10 @@
-const searchMacro = '%%search%%';
-
 // The typed term must never reach the URL raw: it travels as a query-string value, so
 // every reserved character has to be percent-encoded. The replacement is passed as a
 // function on purpose - String.replace with a string replacement treats `$&`, `$'`,
 // backtick-$ and `$1` as capture references, and encodeURIComponent leaves `$` untouched.
 const buildAutocompleteRequestURL = (searchTerm: string): string => {
     const encodedSearchTerm = encodeURIComponent(searchTerm);
-    return window.config.routes.autocomplete.replace(searchMacro, () => encodedSearchTerm);
+    return window.config.routes.autocomplete.replace('%%search%%', () => encodedSearchTerm);
 };
 
 export default buildAutocompleteRequestURL;

--- a/be/src/index.ts
+++ b/be/src/index.ts
@@ -27,7 +27,8 @@ app.use(cors({origin}));
 app.get('/test', (req: Request, res: Response) => {
     res.status(200).json({message:'Server is running 🍍☺', success: true});
 });
-app.get('/autocomplete/:search', autoCompleteRoute);
+app.get('/autocomplete', autoCompleteRoute);
+app.get('/autocomplete/:search', autoCompleteRoute); // legacy, remove once configs are updated
 app.get('/card/:card_id', [sanitizeCardRoute, cardRoute]);
 app.post('/search', searchRoute);
 app.post('/logs/:provider', logRoute);

--- a/be/src/routes/autoCompleteRoute.ts
+++ b/be/src/routes/autoCompleteRoute.ts
@@ -9,9 +9,14 @@ import {
 import {pickTopAutocomplete} from "../utilities/mergeAutocompleteUtilities";
 import ensureAutocompleteFallback from "../utilities/ensureAutocompleteFallback";
 import extractServiceForAutocomplete from "../utilities/extractServiceForAutocomplete";
+import resolveAutocompleteSearchTerm from "../utilities/resolveAutocompleteSearchTerm";
+
+const emptyAutocomplete = {structured: [], unstructured: []};
 
 export default asyncHandler(async (req: Request, res: Response) => {
-    const {search} = req.params
+    const search = resolveAutocompleteSearchTerm(req);
+    if (!search) return res.status(200).json({success: true, data: emptyAutocomplete});
+
     const rawAutoComplete = await autoComplete(search);
     const autocomplete = transformAutocompleteUtilities(rawAutoComplete.autoCompleteResults, true);
     const autoCompleteFromCard = transformAutoCompleteFromCardStructure(rawAutoComplete.autoCompleteFromCardResults);

--- a/be/src/utilities/resolveAutocompleteSearchTerm.ts
+++ b/be/src/utilities/resolveAutocompleteSearchTerm.ts
@@ -1,0 +1,12 @@
+import {Request} from "express";
+
+// The term arrives as a query-string value. A repeated `?search=` makes Express hand back
+// an array, so only a plain string is accepted. `req.params.search` covers the legacy
+// path-segment route and can be dropped together with it.
+const resolveAutocompleteSearchTerm = (req: Request): string => {
+    const searchFromQuery = req.query.search;
+    if (typeof searchFromQuery === 'string') return searchFromQuery.trim();
+    return (req.params.search || '').trim();
+};
+
+export default resolveAutocompleteSearchTerm;


### PR DESCRIPTION
## Problem

Typing a lone `.` into either search input white-screens the whole app.

The autocomplete term was interpolated into a URL **path segment** — `window.config.routes.autocomplete` was `/autocomplete/%%search%%`. A lone `.` is a *dot-segment*, so the browser strips it per RFC 3986 **before the request leaves**: `/autocomplete/.` → `/autocomplete/`. The BE only registered `GET /autocomplete/:search`, which requires a non-empty segment → 404 → axios rejects → `sendMessage` returns `{error}` → `response.data` is `undefined` → that `undefined` is stored into state typed as non-nullable `AutocompleteType` → the next render dereferences `.structured.length` and throws. With no error boundary in the app, React unmounts the entire tree.

Worth calling out: **`encodeURIComponent` alone does not fix this.** `.` is unreserved, and the URL parser decodes `%2E` before dot-segment removal — `/autocomplete/%2E` collapses too. That ruled out the obvious one-line fix.

The same defect broke other characters, some worse than a white screen: `..`, `/`, `#`, `?` mis-routed, and a bare `%` threw in Express's param decoder → `errorHandler` fired **an alert email per keystroke**. Input is debounced at 500 ms with no Enter required, so a single character was enough.

## Fix

The term now travels as a query-string value, which no normalization rule touches.

| File | Change |
|---|---|
| `FE/public/configs/config.json` | Route is now `/autocomplete?search=%%search%%` |
| `FE/src/services/searchUtilities/buildAutocompleteRequestURL.ts` *(new)* | Percent-encodes the term; substitutes via a **replacer function**, since `String.replace` with a string replacement treats `$&`/`$1` as capture references — typing `$&` used to inject the `%%search%%` macro back into the URL |
| `FE/src/hooks/useSearchAutocomplete.ts` | Guards the response (`response?.success && response.data`), mirroring the existing pattern in `fetchResults.ts:25`; skips whitespace-only terms |
| `be/src/index.ts` | Adds `GET /autocomplete`, keeps the path route as a marked legacy alias |
| `be/src/routes/autoCompleteRoute.ts` + `be/src/utilities/resolveAutocompleteSearchTerm.ts` *(new)* | Reads the term from the query (params fallback); short-circuits blank input to empty buckets instead of querying ES |

The legacy path route is deliberately kept: `config.json` is volume-mounted in `docker-compose`, so the deployed config can lag a BE deploy. Keeping both routes makes deploy order irrelevant. It's marked for removal once configs are updated.

## Verification

The autocomplete/card indices aren't available locally (the local elastic container holds none, and staging ES needs VPN), so a throwaway fake Elasticsearch was used to exercise the real handler path end to end on a separate port — no changes to any `.env`.

**Backend** — `.` `..` `/` `#` `?` `%` `$&`, Hebrew, and spaces all return **200** with the term round-tripping intact. Blank / missing / whitespace-only / repeated `?search=` return 200 empty with **zero** ES calls (22 searches observed = 11 real terms × 2 queries). Legacy path route still 200.

**Frontend** — every character above typed into both inputs (homepage and results-page header): app stays mounted, **zero** console errors, suggestions still render for real terms. Network shows only `/autocomplete?search=…` → 200, correctly encoded; nothing hits `/autocomplete/`.

**Deploy-lag check** — with `config.json` pointed back at the old path template, ordinary terms still work *and* `.` no longer crashes: it collapses to `/autocomplete/`, which the new route answers 200. Covered from both sides.

**No alert emails** — zero `errorHandler` entries across the entire run.

## Notes for the reviewer

- **No error boundary was added** — deliberately out of scope for this PR. It remains the reason any future bad state shape white-screens rather than degrading, and is worth a follow-up.
- `tsc --noEmit` reports 5 pre-existing implicit-`any` errors in `useDebounce.ts` and `useOnce.ts` (untouched here; `npm run build` is plain `vite build` and never ran tsc). The files changed in this PR typecheck clean, and the BE typechecks clean.
- Separately noticed while verifying: the local `be/.env` points at elastic `:9200`, but the running container publishes `:9199` — so a local BE can't reach it. Not touched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
